### PR TITLE
Corrected names of two states

### DIFF
--- a/Country Lists/India/India States.xml
+++ b/Country Lists/India/India States.xml
@@ -24,7 +24,7 @@
 	<item>Meghalaya</item>
 	<item>Mizoram</item>
 	<item>Nagaland</item>
-	<item>Orissa</item>
+	<item>Odisha</item>
 	<item>Pondicherry</item>
 	<item>Punjab</item>
 	<item>Rajasthan</item>
@@ -32,7 +32,7 @@
 	<item>Tamil Nadu</item>
 	<item>Telangana</item>
 	<item>Tripura</item>
-	<item>Uttaranchal</item>
+	<item>Uttarakhand</item>
 	<item>Uttar Pradesh</item>
 	<item>West Bengal</item>
 </string-array>


### PR DESCRIPTION
Uttaranchal has been renamed to Uttarakhand in 2006
Also, Odisha is an official name (orissa is not official name)

Name can be verified from here https://en.wikipedia.org/wiki/List_of_state_and_union_territory_capitals_in_India